### PR TITLE
feat: add markdown templates for skills exercises feedback and progress

### DIFF
--- a/markdown-templates/README.md
+++ b/markdown-templates/README.md
@@ -1,0 +1,31 @@
+# Skills Exercises Markdown Templates
+
+A collection of templates for use in Skills exercises.
+
+## Template Collections
+
+- `/readme/*` - templates intended for updating an exercise's root readme file.
+- `/step-feedback/*` - templates for sharing step progress, grading pass/fail, and congratulations. Typically used for issue comments.
+
+## Template Variables
+
+Several templates contain [mustache style variables](https://mustache.github.io/mustache.5.html). They are intended for use with the [skills/action-text-variables](https://github.com/skills/action-text-variables) GitHub Action, which supports full mustache templating.
+
+### Example
+
+#### hello.md
+
+```markdown
+Hello {{ login }}, nice to meet you!
+```
+
+#### json input
+
+```json
+{
+  "login": "${{ github.actor }}"
+}
+```
+
+> [!TIP]
+> See [mustache syntax](https://mustache.github.io/mustache.5.html) for all capabilities like iteration and if/then logic.

--- a/markdown-templates/readme/congratulations.md
+++ b/markdown-templates/readme/congratulations.md
@@ -1,0 +1,12 @@
+<img src="https://octodex.github.com/images/welcometocat.png" align="right" height="250px" />
+
+⭐️ Congratulations {{ login }}! ⭐️
+
+You completed this lesson! Nice work! 🥳
+
+If you would like to practice again, you can retrace your steps below. Just press the **Start Lesson** button again.
+
+> [!TIP]
+> Mona won't grade you this time! 😉
+
+{{ final_message }}

--- a/markdown-templates/step-feedback/checking-work.md
+++ b/markdown-templates/step-feedback/checking-work.md
@@ -1,0 +1,4 @@
+<img src="https://octodex.github.com/images/inspectocat.jpg" align="right" height="100px" />
+
+Nice! Looks like you are making progress.    
+Let's see if I have some feedback for you... 🧐

--- a/markdown-templates/step-feedback/lesson-finished.md
+++ b/markdown-templates/step-feedback/lesson-finished.md
@@ -1,0 +1,7 @@
+<img src="https://octodex.github.com/images/welcometocat.png" align="left" height="150px" />
+
+Congratulations **{{ login }}**! You finished the exercise! 🎉🎉🎉
+
+We've updated the repository with a couple changes to highlight your success!
+
+Return to the [repository home](/{{ repo_full_name }}) page to see your progress!

--- a/markdown-templates/step-feedback/lesson-review.md
+++ b/markdown-templates/step-feedback/lesson-review.md
@@ -1,0 +1,4 @@
+<img src="https://octodex.github.com/images/Professortocat_v2.png" align="right" height="100px" />
+
+🎉🎉🎉  Nice work! Everything is perfect! 🎉🎉🎉   
+Now, let's do a quick review!

--- a/markdown-templates/step-feedback/step-finished-prepare-next-step.md
+++ b/markdown-templates/step-feedback/step-finished-prepare-next-step.md
@@ -1,0 +1,4 @@
+<img src="https://octodex.github.com/images/Professortocat_v2.png" align="right" height="100px" />
+
+🎉🎉🎉  Nice work! Everything is perfect! 🎉🎉🎉   
+Preparing content for step {{ next_step_number }}! One moment... 🤓

--- a/markdown-templates/step-feedback/step-results.md
+++ b/markdown-templates/step-feedback/step-results.md
@@ -1,0 +1,30 @@
+{{#passed}}
+## Step {{ step_number }} - Passed ✅
+{{/passed}}
+{{^passed}}
+## Step {{ step_number }} - Fail ❌
+{{/passed}}
+
+{{#passed}}
+<img src="https://octodex.github.com/images/inflatocat.png" align="right" height="200px" />
+{{/passed}}
+{{^passed}}
+<img src="https://octodex.github.com/images/spidertocat.png" align="right" height="100px" />
+Some checks failed. Please review the results below and try again.
+
+Time to find the bug! 🤔
+{{/passed}}
+
+| Status | Name | Message |
+| --- | --- | --- |
+{{#results_table}}
+| {{#passed}}✅ - Pass{{/passed}}{{^passed}}❌ - Fail{{/passed}} | {{ name }} | {{ message }} |
+{{/results_table}}
+
+{{#tips.length}}
+### Tips
+
+{{#tips}}
+- {{.}}
+{{/tips}}
+{{/tips.length}}

--- a/markdown-templates/step-feedback/watching-for-progress.md
+++ b/markdown-templates/step-feedback/watching-for-progress.md
@@ -1,0 +1,4 @@
+<img src="https://octodex.github.com/images/supportcat.png" align="right" height="100px" />
+
+Please, follow the steps above.  
+I'll watch your progress in the background to provide feedback. 🧐

--- a/markdown-templates/step-feedback/welcome.md
+++ b/markdown-templates/step-feedback/welcome.md
@@ -1,0 +1,17 @@
+## {{ title }}
+
+<img src="https://octodex.github.com/images/original.png" align="left" height="80px" />
+
+👋 Hey there {{ login }}! Welcome to your Skills exercise!
+
+{{ intro_message }}
+
+As you complete each step, I will respond in the comments to:
+
+- check your work and give feedback
+- share next steps
+- occasionally share tips
+- congratulate you when you finish!
+
+Good luck and have fun!
+\- Mona


### PR DESCRIPTION
Moved all templates from https://github.com/skills/response-templates repository.

