### PR TITLE
feat: add finish-exercise workflow to update README and close issue upon exercise completion

### DIFF
--- a/.github/workflows/finish-exercise.yml
+++ b/.github/workflows/finish-exercise.yml
@@ -1,0 +1,82 @@
+name: Finish Exercise Workflow
+
+on:
+  workflow_call:
+    inputs:
+      issue-url:
+        description: "The URL of the issue to update and close"
+        required: true
+        type: string
+
+jobs:
+  update_readme:
+    name: Update README with congratulations
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.repository.default_branch }}
+
+      - name: Get response templates
+        uses: actions/checkout@v4
+        with:
+          repository: skills/response-templates
+          path: skills-response-templates
+
+      - name: Build message - congratulations
+        id: build-message-congratulations
+        uses: skills/action-text-variables@v1
+        with:
+          template-file: skills-response-templates/readme/congratulations.md
+          template-vars: |
+            login=${{ github.actor }}
+
+      - name: Update README - congratulations
+        run: |
+          # Add "Congratulations" to the start of the README
+          orig_readme=$(cat README.md)
+          new_readme="$CONTRATULATIONS_TEXT $orig_readme"
+          echo "$new_readme" > README.md
+        env:
+          CONTRATULATIONS_TEXT: ${{ steps.build-message-congratulations.outputs.updated-text }}
+
+      - name: Update README - congratulations
+        uses: EndBug/add-and-commit@v9
+        with:
+          add: "README.md"
+          message: "Congratulations!🎉"
+          default_author: github_actions
+
+  finish_issue:
+    name: Comment and close issue
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Get response templates
+        uses: actions/checkout@v4
+        with:
+          repository: skills/response-templates
+          path: skills-response-templates
+
+      - name: Build message - exercise finished
+        id: build-finish-message
+        uses: skills/action-text-variables@v1
+        with:
+          template-file: skills-response-templates/step-feedback/exercise-finished.md
+          template-vars: |
+            login=${{ github.actor }}
+            repo_full_name=${{ github.repository }}
+
+      - name: Create comment - exercise finished
+        run: |
+          gh issue comment "${{ inputs.issue-url }}" \
+            --body "${{ steps.build-finish-message.outputs.updated-text }}"
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Close issue
+        run: gh issue close "${{ inputs.issue-url }}"
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
This pull request introduces a new GitHub Actions workflow to automate the process of updating the README file and closing issues when an exercise is finished. The workflow is defined in the `.github/workflows/finish-exercise.yml` file.

New workflow creation:

* [`.github/workflows/finish-exercise.yml`](diffhunk://#diff-8488eac6b5d3e290059fd0324a2886dee5d3d09fc748eadfec1acf7c1e02e548R1-R82): Added a new workflow named "Finish Exercise Workflow" that includes two jobs: `update_readme` to update the README file with a congratulatory message and `finish_issue` to comment on and close the related issue.