### PR TITLE
chore: update workflow references from 'dev' to 'main'

### DIFF
--- a/.github/workflows/finish-exercise.yml
+++ b/.github/workflows/finish-exercise.yml
@@ -24,7 +24,7 @@ jobs:
         with:
           repository: skills/exercise-toolkit
           path: exercise-toolkit
-          ref: dev # TODO: Change to tag
+          ref: main # TODO: Change to tag
 
       - name: Build message - congratulations
         id: build-message-congratulations
@@ -59,7 +59,7 @@ jobs:
         with:
           repository: skills/exercise-toolkit
           path: exercise-toolkit
-          ref: dev # TODO: Change to tag
+          ref: main # TODO: Change to tag
 
       - name: Build message - exercise finished
         id: build-finish-message

--- a/.github/workflows/start-exercise.yml
+++ b/.github/workflows/start-exercise.yml
@@ -64,7 +64,7 @@ jobs:
         with:
           repository: skills/exercise-toolkit
           path: exercise-toolkit
-          ref: dev # TODO: Change to tag
+          ref: main # TODO: Change to tag
 
       - name: Build welcome message from template
         id: build-issue-description


### PR DESCRIPTION

This pull request includes changes to the GitHub Actions workflows to update the reference of the `exercise-toolkit` repository from `dev` to `main`. This update affects both the `finish-exercise.yml` and `start-exercise.yml` workflow files.

This will once again be updated to a tag just before first release