### PR TITLE
Add labeler workflow to automatically label pr's

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,0 +1,20 @@
+# Label definitions for actions/labeler
+
+# Templates label for changes to markdown-templates directory
+templates:
+  - changed-files:
+      - any-glob-to-any-file: "markdown-templates/**/*"
+
+# Workflows label for changes to GitHub workflow files (excluding changes that only change workflows prefixed with _)
+workflows:
+  - changed-files:
+      - all-globs-to-any-files:
+        - ".github/workflows/*.yml"
+        - "!.github/workflows/_*.yml"
+
+# Documentation label for root level .md files and files in /docs/ directory
+documentation:
+  - changed-files:
+      - any-glob-to-any-file:
+          - "*.md"
+          - "docs/**/*"

--- a/.github/workflows/_labeler.yml
+++ b/.github/workflows/_labeler.yml
@@ -1,0 +1,15 @@
+name: Label PRs
+on:
+  - pull_request_target
+
+jobs:
+  labeler:
+    name: PR Labeler
+    permissions:
+      contents: read
+      pull-requests: write
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/labeler@v5
+        with:
+          sync-labels: true


### PR DESCRIPTION
This pull request introduces label definitions and a workflow to automatically label pull requests based on the files they modify. The most important changes include the addition of label definitions in the `labeler.yml` file and the creation of a GitHub Actions workflow to apply these labels.

Label definitions:

* [`.github/labeler.yml`](diffhunk://#diff-a22c263686553013feaeb0677d26eeb0b8778a756c4311c1fce13384258026aaR1-R20): Added label definitions for templates, workflows, and documentation based on file path patterns.

Workflow for labeling:

* [`.github/workflows/_labeler.yml`](diffhunk://#diff-851a8921e8d4c99ef4bf455dd148114c2e3e35fc5e58e2d44865e4949a968d3fR1-R15): Created a GitHub Actions workflow to label pull requests using the defined labels. The workflow is triggered on pull request events and uses the `actions/labeler` action.