### PR TITLE
chore: add linting workflow using Super-linter for pull requests

### DIFF
--- a/.github/workflows/_labeler.yml
+++ b/.github/workflows/_labeler.yml
@@ -1,13 +1,14 @@
 name: Label PRs
 on:
-  - pull_request_target
+  pull_request_target:
+
+permissions:
+  contents: read
+  pull-requests: write
 
 jobs:
   labeler:
     name: PR Labeler
-    permissions:
-      contents: read
-      pull-requests: write
     runs-on: ubuntu-latest
     steps:
       - uses: actions/labeler@v5

--- a/.github/workflows/_lint.yml
+++ b/.github/workflows/_lint.yml
@@ -21,3 +21,5 @@ jobs:
         uses: super-linter/super-linter@v7.3.0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          VALIDATE_GITHUB_ACTIONS: true
+          VALIDATE_CHECKOV: true

--- a/.github/workflows/_lint.yml
+++ b/.github/workflows/_lint.yml
@@ -1,0 +1,23 @@
+name: Lint
+
+on:
+  pull_request:
+
+permissions:
+  contents: read
+  statuses: write   # To report GitHub Actions status checks
+
+jobs:
+  lint:
+    name: Lint
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Super-linter
+        uses: super-linter/super-linter@v7.3.0
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/_lint.yml
+++ b/.github/workflows/_lint.yml
@@ -18,7 +18,7 @@ jobs:
           fetch-depth: 0
 
       - name: Super-linter
-        uses: super-linter/super-linter@v7.3.0
+        uses: super-linter/super-linter/slim@v7.3.0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           VALIDATE_GITHUB_ACTIONS: true

--- a/.github/workflows/finish-exercise.yml
+++ b/.github/workflows/finish-exercise.yml
@@ -8,6 +8,10 @@ on:
         required: true
         type: string
 
+permissions:
+  contents: write
+  issues: write
+
 jobs:
   update_readme:
     name: Update README with congratulations

--- a/.github/workflows/start-exercise.yml
+++ b/.github/workflows/start-exercise.yml
@@ -42,7 +42,7 @@ jobs:
           # Find all workflow files that start with a number (0-9)
           workflows=$(git ls-files | grep -E '^\.github/workflows/[0-9].*\.(yml|yaml)$')
           for workflow in $workflows; do
-            workflow_name=$(basename $workflow)
+            workflow_name="$(basename "$workflow")"
             echo "Disabling workflow: $workflow_name"
             gh workflow disable "$workflow_name" || true
           done

--- a/.github/workflows/start-exercise.yml
+++ b/.github/workflows/start-exercise.yml
@@ -78,7 +78,7 @@ jobs:
 
       - name: Create issue - add welcome message
         id: create-issue
-        uses: actions/github-script@v6
+        uses: actions/github-script@v7
         with:
           script: |
             const { data: issue } = await github.rest.issues.create({


### PR DESCRIPTION
This pull request introduces a new GitHub Actions workflow to automate linting for pull requests. The workflow is configured to run on the latest Ubuntu environment and uses the Super-linter action to perform the linting checks.

Key changes:

* [`.github/workflows/_lint.yml`](diffhunk://#diff-bd36eefe702ebcd6e64131c2794b6bf11e7d893db6156f9b014d6d41767c2104R1-R23): Added a new GitHub Actions workflow named "Lint" that triggers on pull requests, checks out the repository, and runs the Super-linter.