### PR TITLE
feat: update start-exercise workflow to replace README with template message

### DIFF
--- a/.github/workflows/start-exercise.yml
+++ b/.github/workflows/start-exercise.yml
@@ -117,6 +117,7 @@ jobs:
           template-vars: |
             title=${{ inputs.exercise-title }}
             login=${{ github.actor }}
+            link_to_exercise=${{ needs.create_exercise.outputs.issue-url }}
 
       - name: Overwrite README
         env:

--- a/.github/workflows/start-exercise.yml
+++ b/.github/workflows/start-exercise.yml
@@ -117,7 +117,7 @@ jobs:
           template-vars: |
             title=${{ inputs.exercise-title }}
             login=${{ github.actor }}
-            link_to_exercise=${{ needs.create_exercise.outputs.issue-url }}
+            issue_url=${{ needs.create_exercise.outputs.issue-url }}
 
       - name: Overwrite README
         env:

--- a/.github/workflows/start-exercise.yml
+++ b/.github/workflows/start-exercise.yml
@@ -102,35 +102,26 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Deactivate 'Copy Exercise' button
-        run: |
-          # Remove href from 'Copy Exercise' button
-          target='id="copy-exercise"[^>]*href="[^"]*"'
-          replacement='id="copy-exercise"'
-          sed -i "s|$target|$replacement|g" README.md
+      - name: Get response templates
+        uses: actions/checkout@v4
+        with:
+          repository: skills/exercise-toolkit
+          path: exercise-toolkit
+          ref: start-exercise-updates
 
-          # Change color from green to gray
-          target=Copy_Exercise-008000
-          replacement=Copy_Exercise-AAA
-          sed -i "s|$target|$replacement|g" README.md
+      - name: Build welcome message from template
+        id: build-new-readme
+        uses: skills/action-text-variables@v1
+        with:
+          template-file: exercise-toolkit/markdown-templates/readme/exercise-started.md
+          template-vars: |
+            title=${{ inputs.exercise-title }}
+            login=${{ github.actor }}
 
-      - name: Activate 'Start Exercise' button
-        run: |
-          # Add link to issue
-          target='id="start-exercise"'
-          replacement='id="start-exercise" href="../../issues/${{ needs.create_exercise.outputs.issue-number }}"'
-          sed -i "s|$target|$replacement|g" README.md
-
-          # Change color from gray to green
-          target=Start_Exercise-AAA
-          replacement=Start_Exercise-008000
-          sed -i "s|$target|$replacement|g" README.md
-
-      - name: Replace relative links
-        run: |
-          target=../../
-          replacement=https://github.com/${{ github.repository }}/
-          sed -i "s|$target|$replacement|g" README.md
+      - name: Overwrite README
+        env:
+          README_TEXT: ${{ steps.build-new-readme.outputs.updated-text }}
+        run: echo "$README_TEXT" > README.md
 
       - name: Commit changes
         uses: EndBug/add-and-commit@v9

--- a/.github/workflows/start-exercise.yml
+++ b/.github/workflows/start-exercise.yml
@@ -107,7 +107,7 @@ jobs:
         with:
           repository: skills/exercise-toolkit
           path: exercise-toolkit
-          ref: start-exercise-updates
+          ref: v0.2.0
 
       - name: Build welcome message from template
         id: build-new-readme

--- a/markdown-templates/readme/exercise-started.md
+++ b/markdown-templates/readme/exercise-started.md
@@ -8,7 +8,7 @@ This is your personal copy of the **{{ title }}** exercise.
 
 **Ready to get started?**
 
-[![](https://img.shields.io/badge/Go%20to%20Exercise-%E2%86%92-brightgreen?style=for-the-badge&logo=github)]({{{ link_to_exercise }}})
+[![](https://img.shields.io/badge/Go%20to%20Exercise-%E2%86%92-brightgreen?style=for-the-badge&logo=github)]({{{ issue_url }}})
 
 _You can come back to the exercise at any point in time if you decide to do it in parts!_
 

--- a/markdown-templates/readme/exercise-started.md
+++ b/markdown-templates/readme/exercise-started.md
@@ -1,17 +1,15 @@
-# The exercise is ready for you  🧑‍🎓 :memo:
+# {{ title }}
 
 <img src="https://octodex.github.com/images/Professortocat_v2.png" align="right" height="200px" />
 
 Hey **{{ login }}**!
 
-This is your personal copy of the **{{ title }}** exercise.
+Mona here. I'm done preparing your exercise. Hope you enjoy! 💚
 
-**Ready to get started?**
-
-[![](https://img.shields.io/badge/Go%20to%20Exercise-%E2%86%92-brightgreen?style=for-the-badge&logo=github)]({{{ issue_url }}})
-
-_You can come back to the exercise at any point in time if you decide to do it in parts!_
-
+Remember, it's self-paced so feel fee to take a break! ☕️
+ 
+[![](https://img.shields.io/badge/Go%20to%20Exercise-%E2%86%92-1f883d?style=for-the-badge&logo=github&labelColor=197935)]({{{ issue_url }}})
+ 
 ---
 
 Get help: [Post in our discussion board](https://github.com/orgs/skills/discussions/categories/) &bull; [Review the GitHub status page](https://www.githubstatus.com/)

--- a/markdown-templates/readme/exercise-started.md
+++ b/markdown-templates/readme/exercise-started.md
@@ -14,6 +14,6 @@ _You can come back to the exercise at any point in time if you decide to do it i
 
 ---
 
-Get help: [Post in our discussion board](https://github.com/orgs/skills/discussions/categories/getting-started-with-github-copilot) &bull; [Review the GitHub status page](https://www.githubstatus.com/)
+Get help: [Post in our discussion board](https://github.com/orgs/skills/discussions/categories/) &bull; [Review the GitHub status page](https://www.githubstatus.com/)
 
 &copy; 2025 GitHub &bull; [Code of Conduct](https://www.contributor-covenant.org/version/2/1/code_of_conduct/code_of_conduct.md) &bull; [MIT License](https://gh.io/mit)

--- a/markdown-templates/readme/exercise-started.md
+++ b/markdown-templates/readme/exercise-started.md
@@ -8,7 +8,7 @@ This is your personal copy of the **{{ title }}** exercise.
 
 **Ready to get started?**
 
-[![](https://img.shields.io/badge/Go%20to%20Exercise-%E2%86%92-brightgreen?style=for-the-badge&logo=github)](google.com)
+[![](https://img.shields.io/badge/Go%20to%20Exercise-%E2%86%92-brightgreen?style=for-the-badge&logo=github)]({{{ link_to_exercise }}})
 
 _You can come back to the exercise at any point in time if you decide to do it in parts!_
 

--- a/markdown-templates/readme/exercise-started.md
+++ b/markdown-templates/readme/exercise-started.md
@@ -1,0 +1,19 @@
+# The exercise is ready for you  🧑‍🎓 :memo:
+
+<img src="https://octodex.github.com/images/Professortocat_v2.png" align="right" height="200px" />
+
+Hey **{{ login }}**!
+
+This is your personal copy of the **{{ title }}** exercise.
+
+**Ready to get started?**
+
+[![](https://img.shields.io/badge/Go%20to%20Exercise-%E2%86%92-brightgreen?style=for-the-badge&logo=github)](google.com)
+
+_You can come back to the exercise at any point in time if you decide to do it in parts!_
+
+---
+
+Get help: [Post in our discussion board](https://github.com/orgs/skills/discussions/categories/getting-started-with-github-copilot) &bull; [Review the GitHub status page](https://www.githubstatus.com/)
+
+&copy; 2025 GitHub &bull; [Code of Conduct](https://www.contributor-covenant.org/version/2/1/code_of_conduct/code_of_conduct.md) &bull; [MIT License](https://gh.io/mit)


### PR DESCRIPTION
## Changes
<!-- Provide a brief description of the changes introduced by this PR -->

Updates to the exercise workflow:

* [`.github/workflows/start-exercise.yml`](diffhunk://#diff-2b8831d4a8274c769a3ccff0b5919260cb9db477eb318d61beb421a1b8033454L105-R124): Removed steps for manually modifying the README file and replaced them with actions to fetch response templates, build a welcome message, and overwrite the README file.

Enhancements to the README template:

* [`markdown-templates/readme/exercise-started.md`](diffhunk://#diff-bf8e96414b284e367a900606ef175ec8422d6ed6cdb6ca689c9015d11d051af2R1-R19): Added a new template for the exercise start message, including a personalized greeting, a visual element, and helpful links.

## Checklist
<!-- Mark the items with an "x" once completed -->
- [ ] I have added or updated appropriate labels to this PR
- [ ] I have tested my changes
- [ ] I have updated the documentation if needed
