### PR TITLE
feat: add `update-readme-with-congratulations` feature flag to`finish-exercise` workflow

### DIFF
--- a/.github/workflows/finish-exercise.yml
+++ b/.github/workflows/finish-exercise.yml
@@ -7,8 +7,8 @@ on:
         description: "The URL of the issue to update and close"
         required: true
         type: string
-      update-readme:
-        description: "Whether to update the README with congratulations message"
+      update-readme-with-congratulations:
+        description: "Whether to update the README with a congratulations message"
         required: false
         type: boolean
         default: true
@@ -21,7 +21,7 @@ jobs:
   update_readme:
     name: Update README with congratulations
     runs-on: ubuntu-latest
-    if: inputs.update-readme
+    if: inputs.update-readme-with-congratulations
 
     steps:
       - name: Checkout

--- a/.github/workflows/finish-exercise.yml
+++ b/.github/workflows/finish-exercise.yml
@@ -7,6 +7,11 @@ on:
         description: "The URL of the issue to update and close"
         required: true
         type: string
+      update-readme:
+        description: "Whether to update the README with congratulations message"
+        required: false
+        type: boolean
+        default: true
 
 permissions:
   contents: write
@@ -16,6 +21,7 @@ jobs:
   update_readme:
     name: Update README with congratulations
     runs-on: ubuntu-latest
+    if: inputs.update-readme
 
     steps:
       - name: Checkout

--- a/.github/workflows/start-exercise.yml
+++ b/.github/workflows/start-exercise.yml
@@ -4,29 +4,24 @@ on:
   workflow_call:
     inputs:
       exercise-title:
-        description: "Title of the exercise"
+        description: 'Title of the exercise'
         required: true
         type: string
       issue-title-prefix:
-        description: "Prefix for the exercise title in the issue"
+        description: 'Prefix for the exercise title in the issue'
         required: false
         type: string
-        default: "Exercise: "
+        default: 'Exercise: '
       intro-message:
-        description: "Introduction message for the exercise"
+        description: 'Introduction message for the exercise'
         required: true
         type: string
-      update-readme:
-        description: "Whether to update the README with start message"
-        required: false
-        type: boolean
-        default: true
     outputs:
       issue-url:
-        description: "URL of the created issue"
+        description: 'URL of the created issue'
         value: ${{ jobs.create_exercise.outputs.issue-url }}
       issue-number:
-        description: "Number of the created issue"
+        description: 'Number of the created issue'
         value: ${{ jobs.create_exercise.outputs.issue-number }}
 
 permissions:
@@ -53,6 +48,7 @@ jobs:
           done
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
 
   create_exercise:
     name: Create exercise issue
@@ -102,7 +98,6 @@ jobs:
     name: Update README
     runs-on: ubuntu-latest
     needs: create_exercise
-    if: inputs.update-readme
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/start-exercise.yml
+++ b/.github/workflows/start-exercise.yml
@@ -4,24 +4,29 @@ on:
   workflow_call:
     inputs:
       exercise-title:
-        description: 'Title of the exercise'
+        description: "Title of the exercise"
         required: true
         type: string
       issue-title-prefix:
-        description: 'Prefix for the exercise title in the issue'
+        description: "Prefix for the exercise title in the issue"
         required: false
         type: string
-        default: 'Exercise: '
+        default: "Exercise: "
       intro-message:
-        description: 'Introduction message for the exercise'
+        description: "Introduction message for the exercise"
         required: true
         type: string
+      update-readme:
+        description: "Whether to update the README with start message"
+        required: false
+        type: boolean
+        default: true
     outputs:
       issue-url:
-        description: 'URL of the created issue'
+        description: "URL of the created issue"
         value: ${{ jobs.create_exercise.outputs.issue-url }}
       issue-number:
-        description: 'Number of the created issue'
+        description: "Number of the created issue"
         value: ${{ jobs.create_exercise.outputs.issue-number }}
 
 permissions:
@@ -48,7 +53,6 @@ jobs:
           done
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
 
   create_exercise:
     name: Create exercise issue
@@ -98,6 +102,7 @@ jobs:
     name: Update README
     runs-on: ubuntu-latest
     needs: create_exercise
+    if: inputs.update-readme
 
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
## Changes
<!-- Provide a brief description of the changes introduced by this PR -->

The main objective of the workflows is to create/close the exercise issue. Updating the README is a feature that, we - in GitHub Skills will use (almost) in all exercises.


## Checklist
<!-- Mark the items with an "x" once completed -->
- [x] I have added or updated appropriate labels to this PR
- [x] I have tested my changes
- [ ] I have updated the documentation if needed
