### PR TITLE
chore: update workflows to use dynamic EXERCISE_TOOLKIT_REF environment variable, add a workflow to update it

### DIFF
--- a/.github/workflows/_update-self-references.yml
+++ b/.github/workflows/_update-self-references.yml
@@ -1,0 +1,60 @@
+name: Update Self-References
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      # Currently reusable workflows only use markdown-templates but this may be extended to actions and other files in the future
+      - "markdown-templates/**"
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  update_versions:
+    name: Update Exercise Toolkit Version References
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Get target version
+        id: version
+        run: |
+          VERSION="${{ github.sha }}"
+          echo "target-version=$VERSION" >> $GITHUB_OUTPUT
+
+      - name: Update EXERCISE_TOOLKIT_REF in workflow files
+        uses: jacobtomlinson/gha-find-replace@v3
+        with:
+          find: 'EXERCISE_TOOLKIT_REF: [^\s]+'
+          replace: "EXERCISE_TOOLKIT_REF: ${{ steps.version.outputs.target-version }}"
+          include: ".github/workflows/*.yml"
+          regex: true
+
+      - name: Create Pull Request
+        uses: peter-evans/create-pull-request@v7
+        with:
+          commit-message: "chore: update exercise-toolkit self-references to ${{ steps.version.outputs.target-version }}"
+          title: "chore: update exercise-toolkit self-references to ${{ steps.version.outputs.target-version }}"
+          body: |
+            ## 🔄 Automated Version Update
+
+            This PR automatically updates the `EXERCISE_TOOLKIT_REF` environment variable in reusable workflows to reference the latest version: **${{ steps.version.outputs.target-version }}**
+
+            ---
+            *This PR was automatically created by the `update-self-references` workflow.*
+          branch: update-self-refs
+          delete-branch: true
+          draft: false
+          reviewers: |
+            FidelusAleksander
+          labels: |
+            skip-release-notes
+            maintenance

--- a/.github/workflows/finish-exercise.yml
+++ b/.github/workflows/finish-exercise.yml
@@ -17,6 +17,9 @@ permissions:
   contents: write
   issues: write
 
+env:
+  EXERCISE_TOOLKIT_REF: v0.5.0
+
 jobs:
   update_readme:
     name: Update README with congratulations
@@ -34,7 +37,7 @@ jobs:
         with:
           repository: skills/exercise-toolkit
           path: exercise-toolkit
-          ref: v0.5.0
+          ref: ${{ env.EXERCISE_TOOLKIT_REF }}
 
       - name: Build congratulations message from template
         id: build-new-readme
@@ -67,7 +70,7 @@ jobs:
         with:
           repository: skills/exercise-toolkit
           path: exercise-toolkit
-          ref: v0.5.0
+          ref: ${{ env.EXERCISE_TOOLKIT_REF }}
 
       - name: Build message - exercise finished
         id: build-finish-message

--- a/.github/workflows/start-exercise.yml
+++ b/.github/workflows/start-exercise.yml
@@ -29,6 +29,9 @@ permissions:
   actions: write # Disable workflows
   issues: write # Create issue
 
+env:
+  EXERCISE_TOOLKIT_REF: v0.5.0
+
 jobs:
   disable_workflows:
     name: Disable exercise workflows
@@ -64,7 +67,7 @@ jobs:
         with:
           repository: skills/exercise-toolkit
           path: exercise-toolkit
-          ref: v0.5.0
+          ref: ${{ env.EXERCISE_TOOLKIT_REF }}
 
       - name: Build welcome message from template
         id: build-issue-description
@@ -107,7 +110,7 @@ jobs:
         with:
           repository: skills/exercise-toolkit
           path: exercise-toolkit
-          ref: v0.5.0
+          ref: ${{ env.EXERCISE_TOOLKIT_REF }}
 
       - name: Build welcome message from template
         id: build-new-readme


### PR DESCRIPTION
## Changes
<!-- Provide a brief description of the changes introduced by this PR -->

This GitHub Actions workflow automatically updates version references in reusable workflow files whenever changes are pushed to the main branch, creating a pull request with the updated `EXERCISE_TOOLKIT_REF` environment variable set to the latest commit SHA.

## Checklist
<!-- Mark the items with an "x" once completed -->
- [ ] I have added or updated appropriate labels to this PR
- [ ] I have tested my changes
- [ ] I have updated the documentation if needed
