### PR TITLE
chore: modify `_update-self-references` workflow to use a PAT

### DIFF
--- a/.github/workflows/_update-self-references.yml
+++ b/.github/workflows/_update-self-references.yml
@@ -57,4 +57,3 @@ jobs:
           draft: false
           labels: |
             skip-release-notes
-            maintenance

--- a/.github/workflows/_update-self-references.yml
+++ b/.github/workflows/_update-self-references.yml
@@ -1,3 +1,7 @@
+# This workflow uses a Personal Access Token instead of built-in GITHUB_TOKEN to create the pull request
+# This is necessary because it commits changes to workflow files, which is not allowed with the default GITHUB_TOKEN.
+# See example https://github.com/peter-evans/create-pull-request/issues/3558
+
 name: Update Self-References
 
 on:
@@ -36,6 +40,7 @@ jobs:
       - name: Create Pull Request
         uses: peter-evans/create-pull-request@v7
         with:
+          token: ${{ secrets.EXERCISE_TOOLKIT_TOKEN }}
           commit-message: "chore: update exercise-toolkit self-references to latest commit"
           title: "chore: update exercise-toolkit self-references to latest commit"
           body: |

--- a/.github/workflows/_update-self-references.yml
+++ b/.github/workflows/_update-self-references.yml
@@ -55,8 +55,6 @@ jobs:
           add-paths: |
             .github/workflows/*.yml
           draft: false
-          reviewers: |
-            FidelusAleksander
           labels: |
             skip-release-notes
             maintenance


### PR DESCRIPTION
## Changes
<!-- Provide a brief description of the changes introduced by this PR -->

Built in secrets.GITHUB_TOKEN does not have permissions to commit to `.github/workflows` directory even with `contents: write` permission. 
The permission `workflows: write` is needed, which can't be granted through the `permission` block. See https://github.com/peter-evans/create-pull-request/issues/3558

* [`.github/workflows/_update-self-references.yml`](diffhunk://#diff-cc9198e1bfdd7777f54aaf20d9be5aaae4aeba51dbb296c80d07d86a0d0e6cffR1-R4): Added comments explaining the use of a Personal Access Token (`EXERCISE_TOOLKIT_TOKEN`) instead of the default `GITHUB_TOKEN` to enable commits to workflow files.
* [`.github/workflows/_update-self-references.yml`](diffhunk://#diff-cc9198e1bfdd7777f54aaf20d9be5aaae4aeba51dbb296c80d07d86a0d0e6cffR43): Updated the `Create Pull Request` step to use the `EXERCISE_TOOLKIT_TOKEN` for authentication.

### Pull request configuration updates:

* [`.github/workflows/_update-self-references.yml`](diffhunk://#diff-cc9198e1bfdd7777f54aaf20d9be5aaae4aeba51dbb296c80d07d86a0d0e6cffL53-L57): Removed the `reviewers` field and adjusted the `labels` field by removing the `maintenance` label.

## Checklist
<!-- Mark the items with an "x" once completed -->
- [x] I have added or updated appropriate labels to this PR
- [x] I have tested my changes
- [ ] I have updated the documentation if needed
