### PR TITLE
feat(socials): share to X(twitter) button in final README

### DIFF
--- a/.github/workflows/finish-exercise.yml
+++ b/.github/workflows/finish-exercise.yml
@@ -47,6 +47,7 @@ jobs:
           template-vars: |
             login: ${{ github.actor }}
             issue_url: ${{ inputs.issue-url }}
+            social_url: https://github.com/${{ github.repository }}
 
       - name: Overwrite README
         env:

--- a/.github/workflows/finish-exercise.yml
+++ b/.github/workflows/finish-exercise.yml
@@ -39,6 +39,21 @@ jobs:
           path: exercise-toolkit
           ref: ${{ env.EXERCISE_TOOLKIT_REF }}
 
+      - name: Encode socials text
+        id: encode-socials-text
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const socialsText = `I just completed a #GitHubSkills exercise! 🎉
+
+            https://github.com/${{ github.repository }}
+
+            #GitHubSkills #OpenSource #GitHub
+            `;
+
+            const encodedText = encodeURIComponent(socialsText);
+            core.setOutput('encoded-text', encodedText);
+
       - name: Build congratulations message from template
         id: build-new-readme
         uses: skills/action-text-variables@v2
@@ -47,7 +62,7 @@ jobs:
           template-vars: |
             login: ${{ github.actor }}
             issue_url: ${{ inputs.issue-url }}
-            social_url: https://github.com/${{ github.repository }}
+            encoded_socials_text: ${{ steps.encode-socials-text.outputs.encoded-text }}
 
       - name: Overwrite README
         env:

--- a/.github/workflows/finish-exercise.yml
+++ b/.github/workflows/finish-exercise.yml
@@ -18,7 +18,7 @@ permissions:
   issues: write
 
 env:
-  EXERCISE_TOOLKIT_REF: dd3788a80f626a1f79fa1b1c3b47b7686f7e1bc2
+  EXERCISE_TOOLKIT_REF: a3125d8f055a01f6827a5caf9ca592711e706750
 
 jobs:
   update_readme:

--- a/.github/workflows/finish-exercise.yml
+++ b/.github/workflows/finish-exercise.yml
@@ -44,11 +44,12 @@ jobs:
         uses: actions/github-script@v7
         with:
           script: |
-            const socialsText = `I just completed a #GitHubSkills exercise! 🎉
+            const repoUrl = `https://github.com/${context.repo.owner}/${context.repo.repo}`;
+            const socialsText = `I just completed a GitHub Skills exercise! 🎉
 
-            https://github.com/${{ github.repository }}
+            ${repoUrl}
 
-            #GitHubSkills #OpenSource #GitHub
+            #GitHubSkills #OpenSource #GitHubLearn
             `;
 
             const encodedText = encodeURIComponent(socialsText);

--- a/markdown-templates/readme/exercise-finished.md
+++ b/markdown-templates/readme/exercise-finished.md
@@ -15,7 +15,7 @@ If you would like to retrace your steps, you can always revisit the exercise.
 
 Show off your new skills and inspire others in the developer community!
 
-<a href="https://twitter.com/intent/tweet?text=I%20just%20completed%20a%20%23GitHubSkills%20exercise%20on%20%40github!%20Check%20it%20out%3A%20{{{ social_url }}}" target="_blank" rel="noopener noreferrer">
+<a href="https://twitter.com/intent/tweet?text={{ encoded_socials_text }}" target="_blank" rel="noopener noreferrer">
   <img src="https://img.shields.io/badge/Share%20on%20X-1da1f2?style=for-the-badge&logo=x&logoColor=white" alt="Share on X" />
 </a>
 

--- a/markdown-templates/readme/exercise-finished.md
+++ b/markdown-templates/readme/exercise-finished.md
@@ -11,6 +11,15 @@ If you would like to retrace your steps, you can always revisit the exercise.
 > [!TIP]
 > Mona won't grade you this time! 😉
 
+### 🚀 Share Your Success!
+
+Show off your new skills and inspire others in the developer community!
+
+<a href="https://twitter.com/intent/tweet?text=I%20just%20completed%20a%20%23GitHubSkills%20exercise%20on%20%40github!%20Check%20it%20out%3A%20{{{ social_url }}}" target="_blank" rel="noopener noreferrer">
+  <img src="https://img.shields.io/badge/Share%20on%20X-1da1f2?style=for-the-badge&logo=x&logoColor=white" alt="Share on X" />
+</a>
+
+---
 
 ### Craving more? :raising_hand:
 


### PR DESCRIPTION
## Changes
<!-- Provide a brief description of the changes introduced by this PR -->

After the exercise is finished we would like to add a share on socials section so people can share their accomplishment on platforms.




## Examples

There are different levels on what can be preconfigured as the user clicks the button. LinkedIn for example does not allow to pre-fill the text of the post, which makes the share to LinkedIn button not ideal (if not pointless). That's why we start with X first, which allows that.

The [opengraph](https://ogp.me/) metadata parameters of the website that post links to is very important when sharing on social media. 


| Link | Links to | Note |
|--------|--------|--------|
| <a href="https://twitter.com/intent/tweet?text=I%20just%20completed%20a%20%23GitHubSkills%20exercise%20on%20%40github!%20Check%20it%20out%3A%20https%3A%2F%2Fskills.github.com" target="_blank" rel="noopener noreferrer"><img src="https://img.shields.io/badge/Share%20on%20X-1da1f2?style=for-the-badge&logo=x&logoColor=white" alt="Share on X" /></a> | https://skills.github.com |  🔴 No opengraph parameters configured  🔴  |
| <a href="https://twitter.com/intent/tweet?text=I%20just%20completed%20a%20%23GitHubSkills%20exercise%20on%20%40github!%20Check%20it%20out%3A%20https%3A%2F%2Fgithub.com" target="_blank" rel="noopener noreferrer"> <img src="https://img.shields.io/badge/Share%20on%20X-1da1f2?style=for-the-badge&logo=x&logoColor=white" alt="Share on X" /></a> | https://github.com/ | 🟢  Nice `og: image` - something to include in GitHub Learn  🟢 |
| <a href="https://twitter.com/intent/tweet?text=I%20just%20completed%20a%20%23GitHubSkills%20exercise%20on%20%40github!%20Check%20it%20out%3A%20https%3A%2F%2Fgithub.com%2Fskills%2Fgithub-pages" target="_blank" rel="noopener noreferrer"> <img src="https://img.shields.io/badge/Share%20on%20X-1da1f2?style=for-the-badge&logo=x&logoColor=white" alt="Share on X" /></a> | skills repository |  🟢 Opengraph configured with social preview urls | 
| <a href="https://twitter.com/intent/tweet?text=I%20just%20completed%20a%20%23GitHubSkills%20exercise%20on%20%40github!%20Check%20it%20out%3A%20https%3A%2F%2Fgithub.com%2FFidelusAleksander%2Fskills-code-with-codespaces" target="_blank" rel="noopener noreferrer"> <img src="https://img.shields.io/badge/Share%20on%20X-1da1f2?style=for-the-badge&logo=x&logoColor=white" alt="Share on X" /></a> | user exercise repository |  🟢 Standard repository opengraph configured | 

## Future enhancements

In the future we can add extra information in the README and the post, e.g
1. Exercise Title
2. Exercise level
3. How long it to complete, see https://github.com/skills/exercise-toolkit/pull/58

## Checklist
<!-- Mark the items with an "x" once completed -->
- [ ] I have added or updated appropriate labels to this PR
- [ ] I have tested my changes
- [ ] I have updated the documentation if needed
