### PR TITLE
feat: add exercise-title optional parameter to finish-exercise workflow

### DIFF
--- a/.github/workflows/finish-exercise.yml
+++ b/.github/workflows/finish-exercise.yml
@@ -9,7 +9,7 @@ on:
         type: string
       exercise-title:
         description: "The title of the exercise"
-        required: true
+        required: false
         type: string
       update-readme-with-congratulations:
         description: "Whether to update the README with a congratulations message"
@@ -52,7 +52,12 @@ jobs:
           script: |
             const repoUrl = `https://github.com/${context.repo.owner}/${context.repo.repo}`;
             const exerciseTitle = process.env.EXERCISE_TITLE;
-            const socialsText = `I just completed the "${exerciseTitle}" GitHub Skills hands-on exercise! 🎉
+
+            const firstLine = exerciseTitle && exerciseTitle.trim() !== ''
+              ? `I just completed the "${exerciseTitle}" GitHub Skills hands-on exercise! 🎉`
+              : `I just completed a GitHub Skills hands-on exercise! 🎉`;
+
+            const socialsText = `${firstLine}
 
             ${repoUrl}
 
@@ -104,8 +109,6 @@ jobs:
           template-vars: |
             login: ${{ github.actor }}
             repo_full_name: ${{ github.repository }}
-            exercise_title: ${{ inputs.exercise-title }}
-
       - name: Create comment - exercise finished
         run: |
           gh issue comment "${{ inputs.issue-url }}" \

--- a/.github/workflows/finish-exercise.yml
+++ b/.github/workflows/finish-exercise.yml
@@ -7,6 +7,10 @@ on:
         description: "The URL of the issue to update and close"
         required: true
         type: string
+      exercise-title:
+        description: "The title of the exercise"
+        required: true
+        type: string
       update-readme-with-congratulations:
         description: "Whether to update the README with a congratulations message"
         required: false
@@ -42,10 +46,13 @@ jobs:
       - name: Encode socials text
         id: encode-socials-text
         uses: actions/github-script@v7
+        env:
+          EXERCISE_TITLE: ${{ inputs.exercise-title }}
         with:
           script: |
             const repoUrl = `https://github.com/${context.repo.owner}/${context.repo.repo}`;
-            const socialsText = `I just completed a GitHub Skills exercise! 🎉
+            const exerciseTitle = process.env.EXERCISE_TITLE;
+            const socialsText = `I just completed the "${exerciseTitle}" GitHub Skills hands-on exercise! 🎉
 
             ${repoUrl}
 
@@ -97,6 +104,7 @@ jobs:
           template-vars: |
             login: ${{ github.actor }}
             repo_full_name: ${{ github.repository }}
+            exercise_title: ${{ inputs.exercise-title }}
 
       - name: Create comment - exercise finished
         run: |


### PR DESCRIPTION
## Changes
<!-- Provide a brief description of the changes introduced by this PR -->


This pull request enhances the `.github/workflows/finish-exercise.yml` workflow by introducing a new **optional** but **recommended** input parameter, `exercise-title`, and integrating it to provide more personalized and descriptive output.


The `exercise-title` should be added not only when calling the `start-exercise` workflow  (as it is already)  but also in`finish-exercise` workflow, ideally with consistency.


## How to adapt

When bumping versions of finish-exercise workflow we will have to remember to add a new parameter `exercise-title`

```yaml
  finish_exercise:
    name: Finish Exercise
    needs: [find_exercise, post_review_content]
    uses: skills/exercise-toolkit/.github/workflows/finish-exercise.yml@<next-tag>
    with:
      issue-url: ${{ needs.find_exercise.outputs.issue-url }}
      exercise-title: "Getting Started with GitHub Copilot" ## new

```

> Potential future improvements could point to reading this value from a configuration file in both workflows


## Checklist
<!-- Mark the items with an "x" once completed -->
- [ ] I have added or updated appropriate labels to this PR
- [ ] I have tested my changes
- [ ] I have updated the documentation if needed
