### PR TITLE
refactor: modify templates to use nunjucks templating

### DIFF
--- a/markdown-templates/readme/exercise-finished.md
+++ b/markdown-templates/readme/exercise-finished.md
@@ -24,7 +24,7 @@
 ### 🎯 What's Next?
 **Keep the momentum going!**
 
-[![](https://img.shields.io/badge/Return%20to%20Exercise-%E2%86%92-1f883d?style=for-the-badge&logo=github&labelColor=197935)]({{{ issue_url }}})
+[![](https://img.shields.io/badge/Return%20to%20Exercise-%E2%86%92-1f883d?style=for-the-badge&logo=github&labelColor=197935)]({{ issue_url | safe }})
 [![GitHub Skills](https://img.shields.io/badge/Explore%20GitHub%20Skills-000000?style=for-the-badge&logo=github&logoColor=white)](https://skills.github.com)
 
 *There's no better way to learn than building things!* 🚀

--- a/markdown-templates/readme/exercise-started.md
+++ b/markdown-templates/readme/exercise-started.md
@@ -8,7 +8,7 @@ Mona here. I'm done preparing your exercise. Hope you enjoy! 💚
 
 Remember, it's self-paced so feel free to take a break! ☕️
 
-[![](https://img.shields.io/badge/Go%20to%20Exercise-%E2%86%92-1f883d?style=for-the-badge&logo=github&labelColor=197935)]({{{ issue_url }}})
+[![](https://img.shields.io/badge/Go%20to%20Exercise-%E2%86%92-1f883d?style=for-the-badge&logo=github&labelColor=197935)]({{ issue_url | safe }})
 
 ---
 

--- a/markdown-templates/step-feedback/step-results-table.md
+++ b/markdown-templates/step-feedback/step-results-table.md
@@ -1,36 +1,35 @@
-{{#passed}}
+{% if passed %}
 
 ## Step {{ step_number }} - Passed ✅
 
-{{/passed}}
-{{^passed}}
+{% else %}
 
 ## Step {{ step_number }} - Fail ❌
 
-{{/passed}}
+{% endif %}
 
-{{#passed}}
+{% if passed %}
 <img src="https://octodex.github.com/images/inflatocat.png" align="right" height="150px" alt="Inflatocat image indicating the step passed" />
-{{/passed}}
-{{^passed}}
+{% else %}
 <img src="https://octodex.github.com/images/spidertocat.png" align="right" height="100px" alt="Spidertocat image indicating the step failed" />
 Some checks failed. Please review the results below and try again.
 
 Time to find the bug! 🤔
-{{/passed}}
+{% endif %}
 
 | Status | Description |
-| --- | --- |
-{{#results_table}}
-| {{#passed}}✅ - Pass{{/passed}}{{^passed}}❌ - Fail{{/passed}} | {{ description }} |
-{{/results_table}}
+| ------ | ----------- |
 
-{{#tips.length}}
+{% for row in results_table %}
+| {% if row.passed %}✅ - Pass{% else %}❌ - Fail{% endif %} | {{ row.description }} |
+{% endfor %}
+
+{% if tips and tips.length %}
 
 ### Tips
 
-{{#tips}}
+{% for tip in tips %}
 
-- {{.}}
-  {{/tips}}
-  {{/tips.length}}
+- {{ tip }}
+{% endfor %}
+{% endif %}


### PR DESCRIPTION
## Changes
<!-- Provide a brief description of the changes introduced by this PR -->

Considering to use https://mozilla.github.io/nunjucks/ instead of https://mustache.github.io/mustache.5.html

Benefits:
- supported by https://github.com/GrantBirki/comment - we could use that for all issue comments to exercises instead of `gh` cli
- extended capabilities like control flow

This PR ideally should to be paired with a new release of the `skills/action-text-variables`

## Checklist
<!-- Mark the items with an "x" once completed -->
- [ ] I have added or updated appropriate labels to this PR
- [ ] I have tested my changes
- [ ] I have updated the documentation if needed
