### PR TITLE
fix: update find-exercise workflow to also work on closed issues

### DIFF
--- a/.github/workflows/find-exercise-issue.yml
+++ b/.github/workflows/find-exercise-issue.yml
@@ -38,6 +38,7 @@ jobs:
             const response = await github.rest.issues.listForRepo({
               owner: context.repo.owner,
               repo: context.repo.repo,
+              state: 'all',
               sort: 'created',    // Sort by creation date
               direction: 'desc',  // Newest first (descending order)
               per_page: 50


### PR DESCRIPTION
## Changes
<!-- Provide a brief description of the changes introduced by this PR -->

This could be useful in some occasions, one that I've run into is people completing the Getting Started with Copilot exercise and only after finishing they notice the bonus step. 
The bonus step workflow was still enabled, but it would fail because the `find-exercise` workflow was only looking for open issues.

https://docs.github.com/en/rest/issues/issues?apiVersion=2022-11-28#list-repository-issues
![image](https://github.com/user-attachments/assets/7df2e129-25b6-438b-aa66-f0aecb1f2c5d)


## Checklist
<!-- Mark the items with an "x" once completed -->
- [x] I have added or updated appropriate labels to this PR
- [x] I have tested my changes
- [ ] I have updated the documentation if needed
