### PR TITLE
fix: remove a conditional that prevented image url updates for repositories created from private repository templates

### DIFF
--- a/.github/workflows/start-exercise.yml
+++ b/.github/workflows/start-exercise.yml
@@ -92,7 +92,6 @@ jobs:
             }
 
       - name: Find and replace image URLs in step files
-        if: steps.get-template-repo.outputs.TEMPLATE_REPOSITORY != ''
         uses: actions/github-script@v8
         env:
           STEP_FILES_GLOB: .github/steps/*.md


### PR DESCRIPTION
This pull request makes a minor update to the workflow configuration by removing a conditional check from the "Find and replace image URLs in step files" job step. This simplifies the workflow and ensures that the step always runs, regardless of the template repository output.

## Changes
<!-- Provide a brief description of the changes introduced by this PR -->

## Checklist
<!-- Mark the items with an "x" once completed -->
- [ ] I have added or updated appropriate labels to this PR
- [ ] I have tested my changes
- [ ] I have updated the documentation if needed
